### PR TITLE
新規作成画面でのラジオボタン実装

### DIFF
--- a/static/js/common.js
+++ b/static/js/common.js
@@ -17,6 +17,7 @@ function createInputField(event, inputType) {
                     <select name="ques-change" onchange="updateInputField(this, ${questionIndex})">
                         <option value="text">テキスト</option>
                         <option value="checkbox">チェックボックス</option>
+                        <option value="radio">ラジオボタン</option>
                     </select>`;
     newDiv.innerHTML += newInputField;
 
@@ -49,9 +50,24 @@ function addInputField(container, inputType, index) {
                             </div>
                          </div>
                          <div id="options-add-${index}">
-                            <button type="button" class="option-add" onclick="option_add(this, ${index})">＋ オプションを追加</button>
+                            <button type="button" class="option-add" onclick="option_add(this, ${index} ,1)">＋ オプションを追加</button>
                          </div>`;
-    }
+    } else if (inputType === "radio") {
+        inputFieldHtml = `<input type="hidden" name="ques-type" value="radio">
+                         <div id="options-container-${index}">
+                            <div><input type="radio" name="radio${index}">
+                            <input type="text" name="option-text-${index}-1" class="option-text" placeholder="オプション名を入力">
+                            <button type="button" class="option-del" onclick="option_del(this, ${index})">✕</button>
+                            </div>
+                            <div><input type="radio" name="radio${index}">
+                            <input type="text" name="option-text-${index}-2" class="option-text" placeholder="オプション名を入力">
+                            <button type="button" class="option-del" onclick="option_del(this, ${index})">✕</button>
+                            </div>
+                         </div>
+                         <div id="options-add-${index}">
+                            <button type="button" class="option-add" onclick="option_add(this, ${index} , 2)">＋ オプションを追加</button>
+                         </div>`;
+    } 
     container.querySelector('.ques-lane').insertAdjacentHTML('afterend', inputFieldHtml);
 }
 
@@ -72,23 +88,34 @@ function updateInputField(selectElement, questionIndex) {
         quesTypeField.remove();
     }
 
-    // options-add が存在する場合、text タイプでは削除する
+    // options-add が存在する場合削除する
     const optionsAdd = container.querySelector(`#options-add-${questionIndex}`);
-    if (optionsAdd && selectedType === "text") {
+    if (optionsAdd) {
         optionsAdd.remove();
     }
+
+    //オプション数をリセット
+    optionCounters[questionIndex] = 3;
 
     // 新しいタイプに応じてフィールドを追加
     addInputField(container, selectedType, questionIndex);
 }
 
 // オプションを追加する関数
-function option_add(button, Index) {
+function option_add(button, Index , Type_num) {
     const optionsContainer = document.getElementById(`options-container-${Index}`);
     let optionCount = optionCounters[Index]++;
-    const newOption = `<div><input type="checkbox">
-                       <input type="text" name="option-text-${Index}-${optionCount}" class="option-text" placeholder="オプション名を入力">
-                       <button type="button" class="option-del" onclick="option_del(this, ${Index})">✕</button></div>`;
+
+    if (Type_num == 1) {
+        newOption = `<div><input type="checkbox">
+               <input type="text" name="option-text-${Index}-${optionCount}" class="option-text" placeholder="オプション名を入力">
+               <button type="button" class="option-del" onclick="option_del(this, ${Index})">✕</button></div>`;
+    } else if (Type_num == 2) {
+        newOption = `<div><input type="radio" name="radio${Index}">
+               <input type="text" name="option-text-${Index}-${optionCount}" class="option-text" placeholder="オプション名を入力">
+               <button type="button" class="option-del" onclick="option_del(this, ${Index})">✕</button></div>`;
+    }
+    
     optionsContainer.insertAdjacentHTML('beforeend', newOption);
 }
 

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -176,3 +176,68 @@ function updateQuestionIndices() {
 
     questionIndex = questionContainers.length + 1;
 }
+
+//タイトルやオプションが空欄で送信される際にメッセージを出す処理
+document.addEventListener('DOMContentLoaded', () => {
+    if (!document.getElementById('create-ques-btn')) {
+        return;
+    }
+    const createBtn = document.getElementById('create-ques-btn');
+    const tempBtn = document.getElementById('tem-ques-btn');
+
+    function validateInputs() {
+        const titleText = document.querySelector('.title-text');
+        const quesTitles = document.querySelectorAll('.ques-title');
+        const optionTexts = document.querySelectorAll('.option-text');
+
+        let errors = [];
+        let check = true;
+
+        // タイトルのチェック
+        if (!titleText.value.trim()) {
+            errors.push('タイトルが入力されていません。');
+        }
+
+        // 質問タイトルのチェック
+        quesTitles.forEach((quesTitle) => {
+            if (!quesTitle.value.trim()) {
+                check = false; 
+            }
+        });
+        if(check != true){
+            errors.push('未入力の質問タイトルがあります。');
+            check = true
+        }
+
+        // オプション名のチェック
+        optionTexts.forEach((optionText) => {
+            if (!optionText.value.trim()) {
+                check = false;
+            }
+        });
+        if(check != true){
+            errors.push('未入力のオプションがあります。');
+            check = true
+        }
+
+        // エラーがあれば警告表示
+        if (errors.length > 0) {
+            alert(errors.join('\n'));
+            return false;
+        }
+
+        return true;
+    }
+
+    createBtn.addEventListener('click', (e) => {
+        if (!validateInputs()) {
+            e.preventDefault(); // フォームの送信を防ぐ
+        }
+    });
+
+    tempBtn.addEventListener('click', (e) => {
+        if (!validateInputs()) {
+            e.preventDefault(); // フォームの送信を防ぐ
+        }
+    });
+});

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -15,6 +15,9 @@ def list_ques(request):
     return render(request, 'surveys/list_ques.html', listdict)
 
 def create_ques(request):
+    listdict = {
+        'title':'新規作成画面',
+    }
     if request.method == 'POST':
         print("POSTデータ:", request.POST)
         existing_question_count = Survey.objects.count()
@@ -106,7 +109,7 @@ def create_ques(request):
                         )
                         choice.save()
         return redirect(path)
-    return render(request, 'surveys/create_ques.html')
+    return render(request, 'surveys/create_ques.html', listdict)
 
 def al_list(request):
     survey_field_data = Survey.objects.filter(published_flag=True)

--- a/templates/surveys/create_ques.html
+++ b/templates/surveys/create_ques.html
@@ -25,8 +25,8 @@
     <div class="submit-container">
         <!-- 質問を作成 -->
         <div class="create-ques">
-            <button type="submit" class="create-ques-btn" id="create-ques-btn" name="action" value="create">質問を公開</button>
-            <button type="submit" class="tem-ques-btn" id="tem-ques-btn" name="action" value="tem">下書きで保存</button>
+            <button type="submit" class="create-ques-btn" id="create-ques-btn" name="action" value="create">公開</button>
+            <button type="submit" class="tem-ques-btn" id="tem-ques-btn" name="action" value="tem">一時保存</button>
             <button type="button" class="cancel-ques-btn" onclick="history.back()">キャンセル</button>
         </div>
     </div>


### PR DESCRIPTION
## 変更点の概要

ラジオボタンの実装と画面に表示される文字の修正

## 今回変更した点（追加した機能など）

common.js
- 質問形式を変更するプルダウンリストに新しく「ラジオ」を追加
- タイトルやオプションが空欄のまま送信される際に警告が出る処理を追加

views.py
 - タブタイトルに「新規作成画面」と出るようにした

create-ques.html
 - 公開ボタンと一時保存ボタンの見た目を修正

## 今回やらなかったこと（次回プルリクで行うものなど）

なし

## この変更でできるようになること

新しくラジオボタン形式の質問を作成できるようになる

## できなくなること

何も入力しないまま質問を作成すること

## 動作確認

【動作確認１】新規作成画面で形式を「ラジオ」に変更

【結果１】ラジオボタン形式の質問に変更された
![image](https://github.com/user-attachments/assets/ef496868-4f56-4ec7-bf5e-54b1c3f1f066)

【動作確認２】何も入力しないまま「公開」ボタンを押す

【結果２】きちんと警告が出現した
![image](https://github.com/user-attachments/assets/8f578014-3765-46d2-95b7-731c4436428c)

## その他・疑問点など


