### PR TITLE
新規作成画面でのプルダウンリストの実装

### DIFF
--- a/static/js/common.js
+++ b/static/js/common.js
@@ -17,6 +17,7 @@ function createInputField(event, inputType) {
                     <select name="ques-change" onchange="updateInputField(this, ${questionIndex})">
                         <option value="text">テキスト</option>
                         <option value="checkbox">チェックボックス</option>
+                        <option value="radio">ラジオボタン</option>
                     </select>`;
     newDiv.innerHTML += newInputField;
 
@@ -49,9 +50,24 @@ function addInputField(container, inputType, index) {
                             </div>
                          </div>
                          <div id="options-add-${index}">
-                            <button type="button" class="option-add" onclick="option_add(this, ${index})">＋ オプションを追加</button>
+                            <button type="button" class="option-add" onclick="option_add(this, ${index} ,1)">＋ オプションを追加</button>
                          </div>`;
-    }
+    } else if (inputType === "radio") {
+        inputFieldHtml = `<input type="hidden" name="ques-type" value="radio">
+                         <div id="options-container-${index}">
+                            <div><input type="radio" name="radio${index}">
+                            <input type="text" name="option-text-${index}-1" class="option-text" placeholder="オプション名を入力">
+                            <button type="button" class="option-del" onclick="option_del(this, ${index})">✕</button>
+                            </div>
+                            <div><input type="radio" name="radio${index}">
+                            <input type="text" name="option-text-${index}-2" class="option-text" placeholder="オプション名を入力">
+                            <button type="button" class="option-del" onclick="option_del(this, ${index})">✕</button>
+                            </div>
+                         </div>
+                         <div id="options-add-${index}">
+                            <button type="button" class="option-add" onclick="option_add(this, ${index} , 2)">＋ オプションを追加</button>
+                         </div>`;
+    } 
     container.querySelector('.ques-lane').insertAdjacentHTML('afterend', inputFieldHtml);
 }
 
@@ -72,23 +88,34 @@ function updateInputField(selectElement, questionIndex) {
         quesTypeField.remove();
     }
 
-    // options-add が存在する場合、text タイプでは削除する
+    // options-add が存在する場合削除する
     const optionsAdd = container.querySelector(`#options-add-${questionIndex}`);
-    if (optionsAdd && selectedType === "text") {
+    if (optionsAdd) {
         optionsAdd.remove();
     }
+
+    //オプション数をリセット
+    optionCounters[questionIndex] = 3;
 
     // 新しいタイプに応じてフィールドを追加
     addInputField(container, selectedType, questionIndex);
 }
 
 // オプションを追加する関数
-function option_add(button, Index) {
+function option_add(button, Index , Type_num) {
     const optionsContainer = document.getElementById(`options-container-${Index}`);
     let optionCount = optionCounters[Index]++;
-    const newOption = `<div><input type="checkbox">
-                       <input type="text" name="option-text-${Index}-${optionCount}" class="option-text" placeholder="オプション名を入力">
-                       <button type="button" class="option-del" onclick="option_del(this, ${Index})">✕</button></div>`;
+
+    if (Type_num == 1) {
+        newOption = `<div><input type="checkbox">
+               <input type="text" name="option-text-${Index}-${optionCount}" class="option-text" placeholder="オプション名を入力">
+               <button type="button" class="option-del" onclick="option_del(this, ${Index})">✕</button></div>`;
+    } else if (Type_num == 2) {
+        newOption = `<div><input type="radio" name="radio${Index}">
+               <input type="text" name="option-text-${Index}-${optionCount}" class="option-text" placeholder="オプション名を入力">
+               <button type="button" class="option-del" onclick="option_del(this, ${Index})">✕</button></div>`;
+    }
+    
     optionsContainer.insertAdjacentHTML('beforeend', newOption);
 }
 

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -18,6 +18,7 @@ function createInputField(event, inputType) {
                         <option value="text">テキスト</option>
                         <option value="checkbox">チェックボックス</option>
                         <option value="radio">ラジオボタン</option>
+                        <option value="select">プルダウン</option>
                     </select>`;
     newDiv.innerHTML += newInputField;
 
@@ -67,6 +68,21 @@ function addInputField(container, inputType, index) {
                          <div id="options-add-${index}">
                             <button type="button" class="option-add" onclick="option_add(this, ${index} , 2)">＋ オプションを追加</button>
                          </div>`;
+    } else if (inputType === "select") {
+        inputFieldHtml = `<input type="hidden" name="ques-type" value="select">
+                         <div id="options-container-${index}">
+                            <div><label id="select-num">1.</label>
+                            <input type="text" name="option-text-${index}-1" class="option-text" placeholder="オプション名を入力">
+                            <button type="button" class="option-del" onclick="option_del(this, ${index})">✕</button>
+                            </div>
+                            <div><label id="select-num">2.</label>
+                            <input type="text" name="option-text-${index}-2" class="option-text" placeholder="オプション名を入力">
+                            <button type="button" class="option-del" onclick="option_del(this, ${index})">✕</button>
+                            </div>
+                         </div>
+                         <div id="options-add-${index}">
+                            <button type="button" class="option-add" onclick="option_add(this, ${index} , 3)">＋ オプションを追加</button>
+                         </div>`;
     } 
     container.querySelector('.ques-lane').insertAdjacentHTML('afterend', inputFieldHtml);
 }
@@ -114,6 +130,10 @@ function option_add(button, Index , Type_num) {
         newOption = `<div><input type="radio" name="radio${Index}">
                <input type="text" name="option-text-${Index}-${optionCount}" class="option-text" placeholder="オプション名を入力">
                <button type="button" class="option-del" onclick="option_del(this, ${Index})">✕</button></div>`;
+    } else if (Type_num == 3) {
+        newOption = `<div><label id="select-num">${optionCount}.</label>
+               <input type="text" name="option-text-${Index}-${optionCount}" class="option-text" placeholder="オプション名を入力">
+               <button type="button" class="option-del" onclick="option_del(this, ${Index})">✕</button></div>`;
     }
     
     optionsContainer.insertAdjacentHTML('beforeend', newOption);
@@ -131,6 +151,11 @@ function updateOptionIndices(Index) {
     const options = optionsContainer.querySelectorAll('.option-text');
     options.forEach((option, index) => {
         option.name = `option-text-${Index}-${index + 1}`;
+
+        const label = option.previousElementSibling;
+        if (label && label.id === "select-num") {
+            label.textContent = `${index + 1}.`;
+        }
     });
     optionCounters[Index] = options.length + 1;
 }

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -176,3 +176,68 @@ function updateQuestionIndices() {
 
     questionIndex = questionContainers.length + 1;
 }
+
+//タイトルやオプションが空欄で送信される際にメッセージを出す処理
+document.addEventListener('DOMContentLoaded', () => {
+    if (!document.getElementById('create-ques-btn')) {
+        return;
+    }
+    const createBtn = document.getElementById('create-ques-btn');
+    const tempBtn = document.getElementById('tem-ques-btn');
+
+    function validateInputs() {
+        const titleText = document.querySelector('.title-text');
+        const quesTitles = document.querySelectorAll('.ques-title');
+        const optionTexts = document.querySelectorAll('.option-text');
+
+        let errors = [];
+        let check = true;
+
+        // タイトルのチェック
+        if (!titleText.value.trim()) {
+            errors.push('タイトルが入力されていません。');
+        }
+
+        // 質問タイトルのチェック
+        quesTitles.forEach((quesTitle) => {
+            if (!quesTitle.value.trim()) {
+                check = false; 
+            }
+        });
+        if(check != true){
+            errors.push('未入力の質問タイトルがあります。');
+            check = true
+        }
+
+        // オプション名のチェック
+        optionTexts.forEach((optionText) => {
+            if (!optionText.value.trim()) {
+                check = false;
+            }
+        });
+        if(check != true){
+            errors.push('未入力のオプションがあります。');
+            check = true
+        }
+
+        // エラーがあれば警告表示
+        if (errors.length > 0) {
+            alert(errors.join('\n'));
+            return false;
+        }
+
+        return true;
+    }
+
+    createBtn.addEventListener('click', (e) => {
+        if (!validateInputs()) {
+            e.preventDefault(); // フォームの送信を防ぐ
+        }
+    });
+
+    tempBtn.addEventListener('click', (e) => {
+        if (!validateInputs()) {
+            e.preventDefault(); // フォームの送信を防ぐ
+        }
+    });
+});

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -15,6 +15,9 @@ def list_ques(request):
     return render(request, 'surveys/list_ques.html', listdict)
 
 def create_ques(request):
+    listdict = {
+        'title':'新規作成画面',
+    }
     if request.method == 'POST':
         print("POSTデータ:", request.POST)
         existing_question_count = Survey.objects.count()
@@ -106,7 +109,7 @@ def create_ques(request):
                         )
                         choice.save()
         return redirect(path)
-    return render(request, 'surveys/create_ques.html')
+    return render(request, 'surveys/create_ques.html', listdict)
 
 def al_list(request):
     survey_field_data = Survey.objects.filter(published_flag=True)

--- a/templates/surveys/create_ques.html
+++ b/templates/surveys/create_ques.html
@@ -25,8 +25,8 @@
     <div class="submit-container">
         <!-- 質問を作成 -->
         <div class="create-ques">
-            <button type="submit" class="create-ques-btn" id="create-ques-btn" name="action" value="create">質問を公開</button>
-            <button type="submit" class="tem-ques-btn" id="tem-ques-btn" name="action" value="tem">下書きで保存</button>
+            <button type="submit" class="create-ques-btn" id="create-ques-btn" name="action" value="create">公開</button>
+            <button type="submit" class="tem-ques-btn" id="tem-ques-btn" name="action" value="tem">一時保存</button>
             <button type="button" class="cancel-ques-btn" onclick="history.back()">キャンセル</button>
         </div>
     </div>


### PR DESCRIPTION
## 変更点の概要

プルダウンの実装

## 今回変更した点（追加した機能など）

common.js
- 質問形式を変更するプルダウンリストに新しく「ラジオ」を追加
- チェックボックスやラジオの様に左に付くものが何もないため代わりにオプション番号を挿入

## 今回やらなかったこと（次回プルリクで行うものなど）

特にないです

## この変更でできるようになること

新しくプルダウン形式の質問を作成できるようになる

## できなくなること

特にないです

## 動作確認

【動作確認１】新規作成画面で形式を「プルダウン」に変更

【結果１】プルダウン形式の質問に変更された
![image](https://github.com/user-attachments/assets/ea7321a4-4aa0-42cc-aa91-3d7e4a34437d)

【動作確認２】オプションを2個追加したのちオプション2を削除し、再び2個追加(オプション番号の順番が崩れないかの確認)

【結果２】オプション番号が崩れることなく追加・削除ができた
<img width="741" alt="オプション結果" src="https://github.com/user-attachments/assets/022ac912-23bc-4d9b-86f2-9a5b274cd2ae">

【動作確認３】保存できるかの確認、下記の4質問を入力して一時保存ボタンを押す
<img width="440" alt="スクリーンショット (49)" src="https://github.com/user-attachments/assets/1025fa6a-8ec1-4b8e-9623-3e0f4592971e">

【結果３】オプションの保存場所がずれることもなく全て保存されていた
<img width="796" alt="スクリーンショット (53)" src="https://github.com/user-attachments/assets/60a9572e-22f6-4685-8597-a299ac379d42">

## その他・疑問点など

特にないです
