### PR TITLE
編集画面での質問編集機能の実装

### DIFF
--- a/static/js/common.js
+++ b/static/js/common.js
@@ -168,3 +168,64 @@ function updateOptionIndices(container, questionIndex) {
         }
     });
 }
+document.addEventListener("DOMContentLoaded", function () {
+    const form = document.querySelector("form");
+
+    form.addEventListener("submit", function (event) {
+        const errors = validateForm();
+        if (errors.length > 0) {
+            event.preventDefault(); // フォームの送信を防止
+            alert(errors.join("\n")); // エラー内容をまとめてアラートで表示
+        }
+    });
+});
+
+function validateForm() {
+    const errors = new Set(); // 重複を防ぐために Set を使用
+
+    // タイトルの検証
+    const titleText = document.querySelector(".title-text");
+    if (!titleText || titleText.value.trim() === "") {
+        errors.add("タイトルが入力されていません。");
+        titleText.classList.add("error");
+    } else {
+        titleText.classList.remove("error");
+    }
+
+    // 各質問の検証
+    const questionContainers = document.querySelectorAll(".ques-container");
+    let questionTitleError = false;
+    let optionTextError = false;
+
+    questionContainers.forEach(container => {
+        const questionTitle = container.querySelector(".ques-title");
+        if (!questionTitle || questionTitle.value.trim() === "") {
+            questionTitleError = true;
+            questionTitle.classList.add("error");
+        } else {
+            questionTitle.classList.remove("error");
+        }
+
+        const optionTexts = container.querySelectorAll(".option-text");
+        optionTexts.forEach(option => {
+            if (!option || option.value.trim() === "") {
+                optionTextError = true;
+                option.classList.add("error");
+            } else {
+                option.classList.remove("error");
+            }
+        });
+    });
+
+    // 質問タイトルのエラーを追加
+    if (questionTitleError) {
+        errors.add("未入力の質問タイトルがあります。");
+    }
+
+    // 選択肢のエラーを追加
+    if (optionTextError) {
+        errors.add("未入力のオプションがあります。");
+    }
+
+    return Array.from(errors); // Set を配列に変換して返す
+}

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,268 +1,170 @@
-// インデックスを管理するオブジェクト
-let optionCounters = {}; // 各質問ごとのオプション数を保持
-let questionIndex = 1;  // 質問ごとのインデックス
+// 質問のインデックス管理
+let questionCounter = 0;
 
-// 質問タイプを選択
+// 質問作成
 function createInputField(event, inputType) {
     event.preventDefault();
+
+    const form = document.querySelector("form");
+    const existingContainers = form.querySelectorAll(".ques-container");
+    questionCounter = existingContainers.length;
+
     const newDiv = document.createElement("div");
     newDiv.classList.add("ques-container");
-    newDiv.dataset.index = questionIndex; // 質問ごとのインデックスを設定
+    newDiv.dataset.index = ++questionCounter;
+
     const addQuesDiv = document.querySelector(".add-ques");
     addQuesDiv.parentNode.insertBefore(newDiv, addQuesDiv);
-    let newInputField = `<div class="ques-lane">
-                    <input type="text" name="ques-title" class="ques-title" placeholder="質問のタイトルを入力">
-                    <img src="/static/img/delbox.png" class="ques-del" onclick="ques_del(this)">
-                    </div>
-                    <select name="ques-change" onchange="updateInputField(this, ${questionIndex})">
-                        <option value="text">テキスト</option>
-                        <option value="checkbox">チェックボックス</option>
-                        <option value="radio">ラジオボタン</option>
-                        <option value="select">プルダウン</option>
-                    </select>`;
-    newDiv.innerHTML += newInputField;
 
-    // 初期オプション数を設定
-    optionCounters[questionIndex] = 3;
+    const newInputField = `
+        <div class="ques-lane">
+            <input type="text" name="ques-title" class="ques-title" placeholder="質問のタイトルを入力">
+            <img src="/static/img/delbox.png" class="ques-del" onclick="deleteQuestion(this)">
+        </div>
+        <select name="ques-change" onchange="updateInputField(this)">
+            <option value="text">テキスト</option>
+            <option value="checkbox">チェックボックス</option>
+            <option value="radio">ラジオボタン</option>
+            <option value="select">プルダウン</option>
+        </select>
+        <div class="input-container"></div>
+    `;
 
-    // 初期の inputType に応じたフィールドを追加
-    addInputField(newDiv, inputType, questionIndex);
-    questionIndex++;
+    newDiv.innerHTML = newInputField;
+    updateInputField(newDiv.querySelector("select"), inputType);
 }
 
-// 質問タイプに応じて入力フィールドを追加
-function addInputField(container, inputType, index) {
-    let inputFieldHtml;
-    if (inputType === "text") {
-        inputFieldHtml = `<input type="hidden" name="ques-type" value="textarea">
-                        <div>
-                            <textarea rows="3" name="ques-text" class="ques-text" placeholder="回答を入力してください" disabled></textarea>
-                        </div>`;
-    } else if (inputType === "checkbox") {
-        inputFieldHtml = `<input type="hidden" name="ques-type" value="checkbox">
-                         <div id="options-container-${index}">
-                            <div><input type="checkbox">
-                            <input type="text" name="option-text-${index}-1" class="option-text" placeholder="オプション名を入力">
-                            <button type="button" class="option-del" onclick="option_del(this, ${index})">✕</button>
-                            </div>
-                            <div><input type="checkbox">
-                            <input type="text" name="option-text-${index}-2" class="option-text" placeholder="オプション名を入力">
-                            <button type="button" class="option-del" onclick="option_del(this, ${index})">✕</button>
-                            </div>
-                         </div>
-                         <div id="options-add-${index}">
-                            <button type="button" class="option-add" onclick="option_add(this, ${index} ,1)">＋ オプションを追加</button>
-                         </div>`;
-    } else if (inputType === "radio") {
-        inputFieldHtml = `<input type="hidden" name="ques-type" value="radio">
-                         <div id="options-container-${index}">
-                            <div><input type="radio" name="radio${index}">
-                            <input type="text" name="option-text-${index}-1" class="option-text" placeholder="オプション名を入力">
-                            <button type="button" class="option-del" onclick="option_del(this, ${index})">✕</button>
-                            </div>
-                            <div><input type="radio" name="radio${index}">
-                            <input type="text" name="option-text-${index}-2" class="option-text" placeholder="オプション名を入力">
-                            <button type="button" class="option-del" onclick="option_del(this, ${index})">✕</button>
-                            </div>
-                         </div>
-                         <div id="options-add-${index}">
-                            <button type="button" class="option-add" onclick="option_add(this, ${index} , 2)">＋ オプションを追加</button>
-                         </div>`;
-    } else if (inputType === "select") {
-        inputFieldHtml = `<input type="hidden" name="ques-type" value="select">
-                         <div id="options-container-${index}">
-                            <div><label id="select-num">1.</label>
-                            <input type="text" name="option-text-${index}-1" class="option-text" placeholder="オプション名を入力">
-                            <button type="button" class="option-del" onclick="option_del(this, ${index})">✕</button>
-                            </div>
-                            <div><label id="select-num">2.</label>
-                            <input type="text" name="option-text-${index}-2" class="option-text" placeholder="オプション名を入力">
-                            <button type="button" class="option-del" onclick="option_del(this, ${index})">✕</button>
-                            </div>
-                         </div>
-                         <div id="options-add-${index}">
-                            <button type="button" class="option-add" onclick="option_add(this, ${index} , 3)">＋ オプションを追加</button>
-                         </div>`;
-    } 
-    container.querySelector('.ques-lane').insertAdjacentHTML('afterend', inputFieldHtml);
-}
-
-// オプションの更新処理
-function updateInputField(selectElement, questionIndex) {
-    const selectedType = selectElement.value;
+// 質問タイプを変更
+function updateInputField(selectElement, inputType = null) {
     const container = selectElement.closest('.ques-container');
-    const existingField = container.querySelector('[name="ques-type"]').nextElementSibling; // 入力フィールドのみ取得
+    const inputContainer = container.querySelector('.input-container');
+    inputContainer.innerHTML = ""; // 既存のフィールドをクリア
 
-    // 既存の入力フィールドを削除
-    if (existingField) {
-        existingField.remove();
-    }
-
-    // hidden ques-type フィールドがある場合に削除
-    const quesTypeField = container.querySelector('input[name="ques-type"]');
-    if (quesTypeField) {
-        quesTypeField.remove();
-    }
-
-    // options-add が存在する場合削除する
-    const optionsAdd = container.querySelector(`#options-add-${questionIndex}`);
-    if (optionsAdd) {
-        optionsAdd.remove();
-    }
-
-    //オプション数をリセット
-    optionCounters[questionIndex] = 3;
-
-    // 新しいタイプに応じてフィールドを追加
-    addInputField(container, selectedType, questionIndex);
+    const selectedInputType = inputType || selectElement.value; // 明示的指定があればそれを優先
+    changeQuestionType(container, selectedInputType);
 }
 
-// オプションを追加する関数
-function option_add(button, Index , Type_num) {
-    const optionsContainer = document.getElementById(`options-container-${Index}`);
-    let optionCount = optionCounters[Index]++;
+// 質問フィールドを変更
+function changeQuestionType(container, inputType) {
+    const inputContainer = container.querySelector('.input-container');
+    const questionIndex = container.dataset.index;
 
-    if (Type_num == 1) {
-        newOption = `<div><input type="checkbox">
-               <input type="text" name="option-text-${Index}-${optionCount}" class="option-text" placeholder="オプション名を入力">
-               <button type="button" class="option-del" onclick="option_del(this, ${Index})">✕</button></div>`;
-    } else if (Type_num == 2) {
-        newOption = `<div><input type="radio" name="radio${Index}">
-               <input type="text" name="option-text-${Index}-${optionCount}" class="option-text" placeholder="オプション名を入力">
-               <button type="button" class="option-del" onclick="option_del(this, ${Index})">✕</button></div>`;
-    } else if (Type_num == 3) {
-        newOption = `<div><label id="select-num">${optionCount}.</label>
-               <input type="text" name="option-text-${Index}-${optionCount}" class="option-text" placeholder="オプション名を入力">
-               <button type="button" class="option-del" onclick="option_del(this, ${Index})">✕</button></div>`;
+    let inputHtml = "";
+
+    switch (inputType) {
+        case "text":
+            inputHtml = `
+                <input type="hidden" name="ques-type" value="textarea">
+                <textarea rows="3" name="ques-text" class="ques-text" placeholder="回答を入力してください" disabled></textarea>
+            `;
+            break;
+        case "checkbox":
+        case "radio":
+        case "select":
+            const inputTypeLabel = inputType === "checkbox" ? "チェックボックス" :
+                inputType === "radio" ? "ラジオボタン" : "プルダウン";
+            inputHtml = `
+                <input type="hidden" name="ques-type" value="${inputType}">
+                <div id="options-container-${questionIndex}" class="options-container">
+                    ${generateOption(questionIndex, 1, inputType)}
+                    ${generateOption(questionIndex, 2, inputType)}
+                </div>
+                <button type="button" class="option-add" onclick="addOption(this)">＋ ${inputTypeLabel}を追加</button>
+            `;
+            break;
     }
-    
-    optionsContainer.insertAdjacentHTML('beforeend', newOption);
+
+    inputContainer.innerHTML = inputHtml;
 }
 
-// オプション削除の関数
-function option_del(button, Index) {
+// オプション生成関数
+function generateOption(questionIndex, optionIndex, inputType) {
+    const inputTag = inputType === "checkbox" ? `<input type="checkbox" disabled>` :
+        inputType === "radio" ? `<input type="radio" name="radio${questionIndex}" disabled>` :
+            `<label>${optionIndex}.</label>`;
+    return `
+        <div class="option">
+            ${inputTag}
+            <input type="text" name="option-text-${questionIndex}-${optionIndex}" class="option-text" placeholder="オプション名を入力">
+            <button type="button" class="option-del" onclick="deleteOption(this,${questionIndex})">✕</button>
+        </div>
+    `;
+}
+
+// オプションを追加
+function addOption(button) {
+    const container = button.previousElementSibling;
+    const questionIndex = container.id.split('-').pop();
+    const optionIndex = container.children.length + 1;
+    const inputType = container.closest('.ques-container').querySelector('input[name="ques-type"]').value;
+
+    const newOption = generateOption(questionIndex, optionIndex, inputType);
+    container.insertAdjacentHTML("beforeend", newOption);
+}
+
+// オプションを削除
+function deleteOption(button, Index) {
+    const container = button.closest(".options-container");
     button.parentElement.remove();
-    updateOptionIndices(Index);
+    updateOptionIndices(container, Index);
 }
 
-// インデックスを再設定
-function updateOptionIndices(Index) {
-    const optionsContainer = document.getElementById(`options-container-${Index}`);
-    const options = optionsContainer.querySelectorAll('.option-text');
-    options.forEach((option, index) => {
-        option.name = `option-text-${Index}-${index + 1}`;
-
-        const label = option.previousElementSibling;
-        if (label && label.id === "select-num") {
-            label.textContent = `${index + 1}.`;
-        }
-    });
-    optionCounters[Index] = options.length + 1;
-}
-
-// 質問削除の関数
-function ques_del(button) {
+// 質問を削除
+function deleteQuestion(button) {
     const container = button.closest('.ques-container');
     if (container) {
-        const questionIndex = parseInt(container.dataset.index, 10);
-        delete optionCounters[questionIndex];
-        container.remove();
-        updateQuestionIndices();
+        container.remove(); // 対象の質問を削除
+        updateQuestionIndices(); // 削除後、インデックスを再割り当て
     }
 }
 
-// 質問インデックスを詰める関数
+// 質問インデックスを更新
 function updateQuestionIndices() {
-    const questionContainers = document.querySelectorAll('.ques-container');
-    questionContainers.forEach((container, index) => {
-        const newIndex = index + 1;
+    const containers = document.querySelectorAll('.ques-container');
+    containers.forEach((container, newIndex) => {
+        const oldIndex = container.dataset.index;
+        const optionsContainer = container.querySelector(`#options-container-${oldIndex}`);
+        const optionsAddButton = container.querySelector(`#options-add-${oldIndex}`);
 
-        // optionsContainerが存在する場合、オプションのインデックスを更新
-        const optionsContainer = container.querySelector(`#options-container-${container.dataset.index}`);
+        // 新しいインデックスを割り当て
+        container.dataset.index = newIndex + 1;
+
+        // options-container の ID を更新
         if (optionsContainer) {
-            optionsContainer.id = `options-container-${newIndex}`;
-            const options = optionsContainer.querySelectorAll('.option-text');
-            options.forEach((option, optionIndex) => {
-                option.name = `option-text-${newIndex}-${optionIndex + 1}`;
-            });
-            optionCounters[newIndex] = options.length + 1;
-        } else {
-            optionCounters[newIndex] = 1;
+            optionsContainer.id = `options-container-${newIndex + 1}`;
+            updateOptionIndices(optionsContainer, newIndex + 1);
         }
 
-        const optionsAdd = container.querySelector(`#options-add-${container.dataset.index}`);
-        if (optionsAdd) {
-            optionsAdd.id = `options-add-${newIndex}`;
+        // オプション追加ボタンの ID と onclick 属性を更新
+        if (optionsAddButton) {
+            optionsAddButton.id = `options-add-${newIndex + 1}`;
             const optionAddButton = container.querySelector('.option-add');
-            optionAddButton.setAttribute('onclick', `option_add(this, ${newIndex})`);
+            optionAddButton.setAttribute('onclick', `addOption(this, ${newIndex + 1})`);
         }
-        container.dataset.index = newIndex;
+
+        // セレクトボックスの onchange 属性を更新
+        const selectElement = container.querySelector('select[name="ques-change"]');
+        if (selectElement) {
+            selectElement.setAttribute('onchange', `updateInputField(this)`);
+        }
     });
 
-    questionIndex = questionContainers.length + 1;
+    questionCounter = containers.length; // 質問数を更新
 }
 
-//タイトルやオプションが空欄で送信される際にメッセージを出す処理
-document.addEventListener('DOMContentLoaded', () => {
-    if (!document.getElementById('create-ques-btn')) {
-        return;
-    }
-    const createBtn = document.getElementById('create-ques-btn');
-    const tempBtn = document.getElementById('tem-ques-btn');
+// オプションインデックスを更新
+function updateOptionIndices(container, questionIndex) {
+    const options = container.querySelectorAll('.option');
+    options.forEach((option, newIndex) => {
+        const input = option.querySelector(".option-text");
+        input.name = `option-text-${questionIndex}-${newIndex + 1}`;
 
-    function validateInputs() {
-        const titleText = document.querySelector('.title-text');
-        const quesTitles = document.querySelectorAll('.ques-title');
-        const optionTexts = document.querySelectorAll('.option-text');
+        const label = option.querySelector("label");
+        if (label) label.textContent = `${newIndex + 1}.`;
 
-        let errors = [];
-        let check = true;
-
-        // タイトルのチェック
-        if (!titleText.value.trim()) {
-            errors.push('タイトルが入力されていません。');
-        }
-
-        // 質問タイトルのチェック
-        quesTitles.forEach((quesTitle) => {
-            if (!quesTitle.value.trim()) {
-                check = false; 
-            }
-        });
-        if(check != true){
-            errors.push('未入力の質問タイトルがあります。');
-            check = true
-        }
-
-        // オプション名のチェック
-        optionTexts.forEach((optionText) => {
-            if (!optionText.value.trim()) {
-                check = false;
-            }
-        });
-        if(check != true){
-            errors.push('未入力のオプションがあります。');
-            check = true
-        }
-
-        // エラーがあれば警告表示
-        if (errors.length > 0) {
-            alert(errors.join('\n'));
-            return false;
-        }
-
-        return true;
-    }
-
-    createBtn.addEventListener('click', (e) => {
-        if (!validateInputs()) {
-            e.preventDefault(); // フォームの送信を防ぐ
+        const deleteButton = option.querySelector(".option-del");
+        if (deleteButton) {
+            deleteButton.setAttribute("onclick", `deleteOption(this,${questionIndex})`);
         }
     });
-
-    tempBtn.addEventListener('click', (e) => {
-        if (!validateInputs()) {
-            e.preventDefault(); // フォームの送信を防ぐ
-        }
-    });
-});
+}

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -181,13 +181,6 @@ def edit_ques(request, survey_id):
         choices = Choice.objects.filter()
     except Survey.DoesNotExist:
         raise Http404("Survey does not exist")
-    listdict = {
-        'edittitle':'編集画面',
-        "title": survey.title,
-        'survey':survey,
-        'question':questions,
-        'choice':choices,
-    }
 
     if request.method == 'POST':
         print("POSTデータ:", request.POST)
@@ -283,6 +276,12 @@ def edit_ques(request, survey_id):
         survey.deleted_flag = True
         survey.save()
         return redirect(path)
+    listdict = {
+        'title':'編集画面',
+        'survey':survey,
+        'question':questions,
+        'choice':choices,
+    }
     return render(request, 'surveys/edit_ques.html', listdict)
 
 @login_required

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -174,11 +174,115 @@ def ag_data(request, survey_id):
 
 @login_required
 def edit_ques(request, survey_id):
-    survey = Survey.objects.get(id = survey_id)
+    try:
+        # Surveyと関連したQuestionを取り出す
+        survey = Survey.objects.get(id=survey_id)
+        questions = Question.objects.filter(survey=survey)
+        choices = Choice.objects.filter()
+    except Survey.DoesNotExist:
+        raise Http404("Survey does not exist")
     listdict = {
-        'title':'編集画面',
+        'edittitle':'編集画面',
+        "title": survey.title,
         'survey':survey,
+        'question':questions,
+        'choice':choices,
     }
+
+    if request.method == 'POST':
+        print("POSTデータ:", request.POST)
+        existing_question_count = Survey.objects.count()
+        next_survey_id = existing_question_count + 1
+
+        survey_title = request.POST.get('title-text')
+        survey_create_user = request.user.email
+
+        path = '/list'
+
+        # 新しいSurveyオブジェクトを作成
+        if request.POST.get('action') == 'create':
+            survey = Survey(
+                id=next_survey_id,
+                title=survey_title,
+                create_at=timezone.now(),
+                create_user=survey_create_user,
+                published_flag=True,
+                deleted_flag=False
+            )
+            survey.save()
+            path = '/al_list'
+        elif request.POST.get('action') == 'tem':
+            survey = Survey(
+                id=next_survey_id,
+                title=survey_title,
+                create_at=timezone.now(),
+                create_user=survey_create_user,
+                published_flag=False,
+                deleted_flag=False
+            )
+            survey.save()
+            path = '/tem_list'
+
+        # 質問と選択肢を処理
+        question_titles = request.POST.getlist('ques-title')
+        question_types = request.POST.getlist('ques-type')
+
+        # ques-title フィールド名をすべて取得してリストに追加
+        for key, value in request.POST.items():
+            if re.match(r'^ques-title-\d+$', key):
+                question_titles.append(value)
+
+        # タイトルとタイプの数が一致しない場合のエラーハンドリング
+        if len(question_titles) != len(question_types):
+            raise ValueError("質問タイトルと質問タイプの数が一致しません")
+
+        # 各質問を保存
+        for i in range(len(question_titles)):
+            existing_question_count = Question.objects.count()
+            next_question_id = existing_question_count + 1
+
+            question_type_text = question_types[i]
+            question_type = Choicetype.objects.get(type=question_type_text)  
+
+            # Questionオブジェクトの作成
+            question = Question(
+                id=next_question_id,
+                title=question_titles[i],
+                survey=survey,
+                type=question_type,
+                deleted_flag=False
+            )
+            question.save()
+
+            # テキストボックスじゃない場合に選択肢を取得
+            if question_type_text != 'textarea':
+                choice_texts = []
+                option_index = 1
+                while True:
+                    choice_key = f'option-text-{i + 1}-{option_index}'
+                    choice_text = request.POST.get(choice_key)
+                    if not choice_text:
+                        break
+                    choice_texts.append(choice_text.strip())
+                    option_index += 1
+
+                # 各選択肢を保存
+                for choice_text in choice_texts:
+                    if choice_text:
+                        existing_question_count = Choice.objects.count()
+                        next_choice_id = existing_question_count + 1
+
+                        choice = Choice(
+                            id=next_choice_id,
+                            text=choice_text,
+                            question=question,
+                            deleted_flag=False
+                        )
+                        choice.save()
+        survey = Survey.objects.get(id=survey_id)
+        survey.deleted_flag = True
+        survey.save()
+        return redirect(path)
     return render(request, 'surveys/edit_ques.html', listdict)
 
 @login_required

--- a/templates/surveys/edit_ques.html
+++ b/templates/surveys/edit_ques.html
@@ -11,7 +11,7 @@
     <div class="container">
         <div class="title-bar">
             <h1>{{ edittitle }}</h1>
-            <input type="text" name="title-text" class="title-text" placeholder="タイトルを入力" value="{{ title }}">
+            <input type="text" name="title-text" class="title-text" placeholder="タイトルを入力" value="{{ survey.title }}">
         </div>
     </div>
 

--- a/templates/surveys/edit_ques.html
+++ b/templates/surveys/edit_ques.html
@@ -1,36 +1,87 @@
 {% extends 'base.html' %}
 
 {% block base %}
-{{ title }}
+{{ edittitle }}
 {% endblock base %}
 
 {% block content %}
 {% load static %}
-
-<div class="container">
-    <input type="text" class="title-text" placeholder="タイトル" value= {{ survey.title }}>
-</div>
-
-<div>
-    <!-- タイトルと削除 -->
-    <div>
-        <input type="text" placeholder="質問のタイトルを入力">
-        <img src="{% static "img/delbox.png" %}" class="ques-del">
+<form method="POST">
+    {% csrf_token %}
+    <div class="container">
+        <div class="title-bar">
+            <h1>{{ edittitle }}</h1>
+            <input type="text" name="title-text" class="title-text" placeholder="タイトルを入力" value="{{ title }}">
+        </div>
     </div>
 
-    <!-- テキストの配置例 -->
-    <div>
-        <textarea rows="3" placeholder="回答を入力してください" disabled></textarea>
+    {% for q in question %}
+    {% with forloop.counter as editid %}
+    <div class="ques-container" data-index="{{editid}}">
+    <div class="ques-lane">
+        <input type="text" name="ques-title" class="ques-title" placeholder="質問のタイトルを入力" value="{{ q.title }}">
+        <img src="/static/img/delbox.png" class="ques-del" onclick="deleteQuestion(this)">
     </div>
-</div>
-    
-<div>
-    <!-- 質問を作成 -->
-    <div>
-        <button type="submit">公開</button>
-        <button type="submit" >一時保存</button>
-        <button onclick="history.back()">キャンセル</button>
+    <select name="ques-change" onchange="updateInputField(this)">
+        <option value="text" {% if q.type.type == "textarea" %}selected{% endif %}>テキスト</option>
+        <option value="checkbox" {% if q.type.type == "checkbox" %}selected{% endif %}>チェックボックス</option>
+        <option value="radio" {% if q.type.type == "radio" %}selected{% endif %}>ラジオボタン</option>
+        <option value="select" {% if q.type.type == "select" %}selected{% endif %}>プルダウン</option>
+    </select>
+
+    {% if q.type.type == "textarea" %}
+    <!-- テキスト入力用のフィールド -->
+    <div class="input-container">
+        <input type="hidden" name="ques-type" value="textarea">
+        <textarea rows="3" name="ques-text" class="ques-text" placeholder="回答を入力してください" disabled></textarea>
     </div>
-    
-</div>
+    </div>
+
+    {% else %}
+    <!-- チェックボックス用のフィールド（複数の選択肢をまとめて表示） -->
+    <div class="input-container">
+        <input type="hidden" name="ques-type" value="{{ q.type.type }}">
+        <div id="options-container-{{editid}}" class="options-container">
+            {% for choice in q.choice_set.all %}
+            {% with forloop.counter as choiceid %}
+            <div class="option">
+                {% if q.type.type == "select" %}
+                <label>{{choiceid}}.</label>
+                {% else %}
+                <input type="{{ q.type.type }}" disabled="">
+                {% endif %}
+                <input type="text" name="option-text-{{editid}}-{{choiceid}}" class="option-text" placeholder="オプション名を入力" value="{{choice.text}}">
+                <button type="button" class="option-del" onclick="deleteOption(this,'{{editid}}')">✕</button>
+            </div>
+            {% endwith %}
+            {% endfor %}    
+        </div>
+        {% if q.type.type == "checkbox" %}
+        <button type="button" class="option-add" onclick="addOption(this)">＋ チェックボックスを追加</button>
+        {% elif q.type.type == "radio" %}
+        <button type="button" class="option-add" onclick="addOption(this)">＋ ラジオボタンを追加</button>
+        {% elif q.type.type == "select" %}
+        <button type="button" class="option-add" onclick="addOption(this)">＋ プルダウンを追加</button>
+        {% endif %}
+    </div>
+    </div>
+    {% endif %}
+    {% endwith %}
+    {% endfor %}
+
+    <div class="add-ques">
+        <!-- 新しい質問を入れるdiv -->
+        <div id="inputFields"></div>
+        <button class="add-ques-btn" id="input-cre" onclick="createInputField(event,'text')">＋ 新規追加</button>
+    </div>
+
+    <div class="submit-container">
+        <!-- 質問を作成 -->
+        <div class="create-ques">
+            <button type="submit" class="create-ques-btn" id="create-ques-btn" name="action" value="create">公開</button>
+            <button type="submit" class="tem-ques-btn" id="tem-ques-btn" name="action" value="tem">一時保存</button>
+            <button type="button" class="cancel-ques-btn" onclick="history.back()">キャンセル</button>
+        </div>
+    </div>
+</form>
 {% endblock content %}


### PR DESCRIPTION
## 変更点の概要

過去に一時保存した質問を編集できる機能の実装

## 今回変更した点（追加した機能など）

common.js
- 無駄の多かったコードをコンパクトに分かりやすく修正(田中さん作)

views.py
- 指定した一時保存の質問を編集画面に持ってくる機能
- 編集画面で変更した質問を新しい質問として保存する機能
- 持ってきた一時保存の質問にデリートフラグを付け画面に表示されなくする機能

edit_ques.html
- 指定した一時保存の質問を表示
- 各ボタンの追加(質問追加、公開、一時保存、キャンセル)

## 今回やらなかったこと（次回プルリクで行うものなど）

デリートフラグが付いている質問を非表示にする機能
質問が1つもない状態で保存されることを阻止するアラート

## この変更でできるようになること

一時保存された質問の編集が行えるようになった

## できなくなること

特にないです

## 動作確認

【動作確認１】下書き一覧画面で一番上にあるタイトル1の「編集」を押し、質問編集画面が表示されるか
![image](https://github.com/user-attachments/assets/858149b0-0752-4eeb-bae9-35e87d855693)

【結果１】ちゃんとすべて表示された
<img width="221" alt="無題" src="https://github.com/user-attachments/assets/40e0d29c-822e-4a49-97fa-bf2048c3d6e6">

【動作確認２】結果１の内容から「タイトル1」を「タイトル2」に変更したのちチェックボックスを削除し、新たに「チェックボックス2」、「チェックオプション3」、「チェックオプション4」を追加して「公開」ボタンを押す

【結果２】公開済みアンケート一覧にタイトル2が追加され、元のタイトル1にデリートフラグが付いた
![image](https://github.com/user-attachments/assets/f38e75d4-6824-47ff-8895-6f2475b08d19)
![image](https://github.com/user-attachments/assets/0433c7df-17c2-4ad4-9cdc-596f9a0cd08b)


## その他・疑問点など

特にないです
