### PR TITLE
一覧画面でのアンケートカードのタイトルがはみ出さないようにCSSを指定

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -139,6 +139,13 @@ a {
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2); /* ホバー時に影を強調 */
 }
 
+.card-header h2 {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
 .card-body p {
   padding-left: 10px;
   font-size: 14px;


### PR DESCRIPTION
## 変更点の概要

一覧画面でのアンケートカードのタイトルがはみ出さないようにCSSを指定

## 今回変更した点（追加した機能など）

- アンケートカードタイトルが長い場合…で省略

## 今回やらなかったこと（次回プルリクで行うものなど）

なし

## この変更でできるようになること

一覧画面の統一感の向上

## できなくなること

なし

## 動作確認

![image](https://github.com/user-attachments/assets/05c1bd47-684c-4b99-b1b3-69235d070ce6)


## その他・疑問点など

なし
