### PR TITLE
公開期間を過ぎたアンケートを一覧画面で表示しないように変更

### DIFF
--- a/surveys/views.py
+++ b/surveys/views.py
@@ -12,7 +12,8 @@ from django.http import HttpResponseRedirect
 @login_required
 def list_ques(request):
     login_user = request.user.email
-    survey_field_data = Survey.objects.exclude(create_user=login_user).filter(published_flag=True, deleted_flag=False)
+    current_time = timezone.now()
+    survey_field_data = Survey.objects.exclude(create_user=login_user).filter(published_flag=True, deleted_flag=False, for_publish__gt=current_time)
     query = request.GET.get('query', '')
     if query:
         survey_field_data = survey_field_data.filter(title__icontains=query)


### PR DESCRIPTION
## 変更点の概要

公開期間を過ぎたアンケートを一覧画面で表示しないように変更

## 今回変更した点（追加した機能など）

- 公開期間を過ぎたアンケートを一覧画面で表示しない機能

## 今回やらなかったこと（次回プルリクで行うものなど）

未定

## この変更でできるようになること

公開期間を過ぎたアンケートを一覧画面で表示しない

## できなくなること

特になし

## その他・疑問点など

作成者が公開期間を過ぎたアンケートを一目でわかるような仕組みが必要だと思う
例）色を変える
　　別画面やタブなどで公開中と公開終了済みを分ける

