### PR TITLE
下書きアンケートを編集すると有効期限設定が表示されないバグの修正

### DIFF
--- a/templates/surveys/edit_ques.html
+++ b/templates/surveys/edit_ques.html
@@ -12,6 +12,20 @@
         <div class="title-bar">
             <h1>{{ edittitle }}</h1>
             <input type="text" name="title-text" class="title-text" placeholder="タイトルを入力" value="{{ survey.title }}">
+            <div class="publish-container">
+                <!-- 公開期間ラベルとプルダウンリスト -->
+                <label for="publish-for_publish" class="publish-label">公開期間</label>
+                <select id="publish-for_publish" class="publish-select">
+                    <option value="unlimited">無期限</option>
+                    <option value="limited">有期限</option>
+                </select>
+
+                <!-- 日時入力フォーム -->
+                <div id="publish-datetime-form" class="publish-datetime-form">
+                    <label for="publish-date" class="publish-label">終了日時:</label>
+                    <input type="datetime-local" id="publish-date" class="publish-input" name="publish_date">
+                </div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
edit_ques.htmlに有効期限を設定するpublish-containerを追加
→下書きから公開する際に有効期限が設定できるようになる