### PR TITLE
質問編集画面での画像追加処理

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1274,6 +1274,7 @@ h2 {
   border-radius: 50%;
   width: 20px;
   height: 20px;
+  padding: 15px;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1133,10 +1133,11 @@ h2 {
 }
 
 .title-text {
-    width: 100%;
+    width: 80%;
     border: none;
     border-bottom: 1px solid #ddd;
     padding: 8px;
+    margin: auto;
     font-size: 24px;
     border-radius: 0;
     outline: none;

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -18,6 +18,14 @@ function createInputField(event, inputType) {
 
     const newInputField = `
         <div class="ques-lane">
+            <div class="image-upload-container">
+                <input type="file" name="ques-image-${questionCounter}" id="file-input-${questionCounter}" class="ques-image" accept="image/*" onchange="previewImage(this, ${questionCounter})" style="display: none;">
+                <div class="image-preview" id="image-preview-${questionCounter}">
+                    <img src="/static/img/def-img.png" alt="画像を選択" class="preview-img" id="upload-btn-${questionCounter}" onclick="triggerFileInput(${questionCounter})" style="cursor: pointer;">
+                    <input type="hidden" name="image-src-${questionCounter}" id="hidden-src-${questionCounter}" value="/static/img/def-img.png">
+                    <button type="button" class="image-del-btn" onclick="removeImage(${questionCounter})" style="display: none;">✕</button>
+                </div>
+            </div>
             <input type="text" name="ques-title" class="ques-title" placeholder="質問のタイトルを入力">
             <img src="/static/img/delbox.png" class="ques-del" onclick="deleteQuestion(this)">
         </div>
@@ -196,13 +204,15 @@ function previewImage(input, editid) {
     const previewContainer = document.getElementById(`image-preview-${editid}`);
     const previewImage = previewContainer.querySelector('.preview-img');
     const deleteButton = previewContainer.querySelector('.image-del-btn');
+    const hiddenInput = document.getElementById(`hidden-src-${editid}`);
 
     if (file) {
         const reader = new FileReader();
 
         reader.onload = function (e) {
             previewImage.src = e.target.result;
-            deleteButton.style.display = 'block'; // 削除ボタンを表示
+            hiddenInput.value = e.target.result;
+            deleteButton.style.display = 'flex'; // 削除ボタンを表示
         };
 
         reader.readAsDataURL(file);
@@ -214,9 +224,11 @@ function removeImage(editid) {
     const previewImage = previewContainer.querySelector('.preview-img');
     const fileInput = document.getElementById(`file-input-${editid}`);
     const deleteButton = previewContainer.querySelector('.image-del-btn');
+    const hiddenInput = document.getElementById(`hidden-src-${editid}`);
 
     // プレビュー画像とファイル入力をリセット
     previewImage.src = "/static/img/def-img.png";
+    hiddenInput.value = "/static/img/def-img.png";
     deleteButton.style.display = 'none';
     fileInput.value = '';
 }
@@ -379,5 +391,16 @@ document.addEventListener("DOMContentLoaded", function() {
             alert("過去の日時が指定されています。アンケートが公開できません。");
             publishDateInput.value = "";
         }
+    });
+});
+
+document.addEventListener("DOMContentLoaded", function() {
+    // "ques-container"の要素をすべて取得
+    const elements = document.querySelectorAll(".ques-container");
+    
+    // 各要素を処理
+    elements.forEach(element => {
+        // data-indexを取得
+        questionCounter = element.getAttribute("data-index");
     });
 });

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -264,6 +264,9 @@ def edit_ques(request, survey_id):
 
         path = '/list'
 
+        #公開期間が設定されなかった場合の値
+        default_for_publish = timezone.now() + timedelta(days=365*100)
+
         # 新しいSurveyオブジェクトを作成
         if request.POST.get('action') == 'create':
             survey = Survey(
@@ -271,6 +274,7 @@ def edit_ques(request, survey_id):
                 title=survey_title,
                 create_at=timezone.now(),
                 create_user=survey_create_user,
+                for_publish=default_for_publish,
                 published_flag=True,
                 deleted_flag=False
             )
@@ -282,6 +286,7 @@ def edit_ques(request, survey_id):
                 title=survey_title,
                 create_at=timezone.now(),
                 create_user=survey_create_user,
+                for_publish=default_for_publish,
                 published_flag=False,
                 deleted_flag=False
             )
@@ -318,6 +323,25 @@ def edit_ques(request, survey_id):
                 deleted_flag=False
             )
             question.save()
+
+            image_file = request.FILES.get(f'ques-image-{i + 1}')
+            upload_btn_path = request.POST.get(f'image-src-{i + 1}')
+            if image_file:
+                # 画像がアップロードされた場合
+                new_filename = f"img-{question.id}.{image_file.name.split('.')[-1]}"
+                image_path = f"question_images/{new_filename}"
+                saved_path = default_storage.save(image_path, ContentFile(image_file.read()))
+                
+                # 画像パスをQuestionに保存
+                question.image = saved_path
+                question.save()
+            elif upload_btn_path != "/static/img/def-img.png":
+                upload_btn_path = upload_btn_path.replace('/static/media/', '')
+                question.image = upload_btn_path
+                question.save()
+            else:
+                question.image = "none"
+                question.save()
 
             # テキストボックスじゃない場合に選択肢を取得
             if question_type_text != 'textarea':

--- a/templates/surveys/edit_ques.html
+++ b/templates/surveys/edit_ques.html
@@ -22,9 +22,17 @@
         <div class="image-upload-container">
             <input type="file" name="ques-image-{{editid}}" id="file-input-{{editid}}" class="ques-image" accept="image/*" onchange="previewImage(this, '{{editid}}')" style="display: none;">
             <div class="image-preview" id="image-preview-{{editid}}">
-                <img src="{% if q.image == 'none' %}/static/img/def-img.png{% else %}/static/media/{{q.image}}{% endif %}" alt="画像を選択" class="preview-img" id="upload-btn-{{editid}}" onclick="triggerFileInput('{{editid}}')" style="cursor: pointer;">
-                <input type="hidden" name="image-src-{{editid}}" id="hidden-src-{{editid}}" value="{% if q.image == 'none' %}/static/img/def-img.png{% else %}/static/media/{{q.image}}{% endif %}">
-                <button type="button" class="image-del-btn" onclick="removeImage('{{editid}}')" {% if q.image == 'none' %}style="display: none;"{% endif %}>✕</button>
+                {% if q.image == 'none' %}
+                    <img src="/static/img/def-img.png" alt="画像を選択" class="preview-img" id="upload-btn-{{editid}}"
+                        onclick="triggerFileInput('{{editid}}')" style="cursor: pointer;">
+                    <input type="hidden" name="image-src-{{editid}}" id="hidden-src-{{editid}}" value="/static/img/def-img.png">
+                    <button type="button" class="image-del-btn" onclick="removeImage('{{editid}}')" style="display: none;">✕</button>
+                {% else %}
+                    <img src="/static/media/{{q.image}}" alt="画像を選択" class="preview-img" id="upload-btn-{{editid}}"
+                        onclick="triggerFileInput('{{editid}}')" style="cursor: pointer;">
+                    <input type="hidden" name="image-src-{{editid}}" id="hidden-src-{{editid}}" value="/static/media/{{q.image}}">
+                    <button type="button" class="image-del-btn" onclick="removeImage('{{editid}}')">✕</button>
+                {% endif %}
             </div>
         </div>
         <input type="text" name="ques-title" class="ques-title" placeholder="質問のタイトルを入力" value="{{ q.title }}">

--- a/templates/surveys/edit_ques.html
+++ b/templates/surveys/edit_ques.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 {% load static %}
-<form method="POST">
+<form method="POST" enctype="multipart/form-data">
     {% csrf_token %}
     <div class="container">
         <div class="title-bar">
@@ -19,6 +19,14 @@
     {% with forloop.counter as editid %}
     <div class="ques-container" data-index="{{editid}}">
     <div class="ques-lane">
+        <div class="image-upload-container">
+            <input type="file" name="ques-image-{{editid}}" id="file-input-{{editid}}" class="ques-image" accept="image/*" onchange="previewImage(this, '{{editid}}')" style="display: none;">
+            <div class="image-preview" id="image-preview-{{editid}}">
+                <img src="{% if q.image == 'none' %}/static/img/def-img.png{% else %}/static/media/{{q.image}}{% endif %}" alt="画像を選択" class="preview-img" id="upload-btn-{{editid}}" onclick="triggerFileInput('{{editid}}')" style="cursor: pointer;">
+                <input type="hidden" name="image-src-{{editid}}" id="hidden-src-{{editid}}" value="{% if q.image == 'none' %}/static/img/def-img.png{% else %}/static/media/{{q.image}}{% endif %}">
+                <button type="button" class="image-del-btn" onclick="removeImage('{{editid}}')" {% if q.image == 'none' %}style="display: none;"{% endif %}>✕</button>
+            </div>
+        </div>
         <input type="text" name="ques-title" class="ques-title" placeholder="質問のタイトルを入力" value="{{ q.title }}">
         <img src="/static/img/delbox.png" class="ques-del" onclick="deleteQuestion(this)">
     </div>

--- a/templates/surveys/edit_ques.html
+++ b/templates/surveys/edit_ques.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block base %}
-{{ edittitle }}
+{{ title }}
 {% endblock base %}
 
 {% block content %}
@@ -10,7 +10,7 @@
     {% csrf_token %}
     <div class="container">
         <div class="title-bar">
-            <h1>{{ edittitle }}</h1>
+            <h1>{{ title }}</h1>
             <input type="text" name="title-text" class="title-text" placeholder="タイトルを入力" value="{{ survey.title }}">
         </div>
     </div>


### PR DESCRIPTION
## 変更点の概要

質問編集画面での画像追加処理

## 今回変更した点（追加した機能など）

- style.css
画像についてる✕ボタンのスタイルの調整
タイトルテキストの横幅を調整

- common.js
前回のプルリクで誤って画像追加処理(25行目を除く21-28行目)が削除されていたので再追加
質問を追加せずに保存処理を行おうとすると「質問を作成してください。」という警告メッセージが出たため、それが出ないようquestionCounterを更新する処理を追加(397-406行目)

- edit_ques.html
大分前にtitleに名称変更されていたedittitleがそのまま放置されていたのでtitleに再設定
画像追加処理、及びDBに保存されている画像パスを参照して画像を表示する処理を追加

- views.py、common.js、edit_ques.html
編集画面で保存処理を行う際、ファイル操作(画像の追加・変更処理)を一度も行わなかった場合に、DBから画像パスを引っ張ってきてるにも関わらずデフォルト画像に変更されてしまう不具合が発生。
それを解消するためにedit_ques.html26行目、views.py338-341行目、common.jsの複数行に「input type="hidden"」関連コードを追加し、DBの画像パス又はデフォルト画像パスをhiddenに代入、ファイル操作が行われずhiddenのvalueがデフォルト画像のパスでない場合にhiddenのパスを保存する処理を追加

- views.py
質問の公開期間を指定する処理がなかったため267-269,277,289行目に臨時で無期限の処理を挿入

## この変更でできるようになること

質問編集画面での画像操作及び保存

## できなくなること

特にないです

## 動作確認

【動作確認１】下記の質問を一時保存し、編集画面に移行。画像が反映されているかの確認。
![image](https://github.com/user-attachments/assets/3e539562-a6bd-4205-b8da-2ef6d7282c01)

【結果１】画像がしっかりと表示された
![image](https://github.com/user-attachments/assets/a1046835-74a7-4959-b0ea-f94be320ec82)

【動作確認２】動作確認１の質問を下記に修正して再び一時保存
![image](https://github.com/user-attachments/assets/270957db-7e77-4194-9f2b-70cdfdb13df1)

【結果２】きちんと挿入・削除されていた(見た目ほぼ変わらないので分かりづらくてすみません)
![image](https://github.com/user-attachments/assets/02b5e7d6-56d5-41b7-931c-01a9a097c420)

## その他・疑問点など

今回変更した点でも説明した通り、views.pyの267-269,277,289行目に公開期限の処理を仮入れしているので今後修正する際は注意してください
