### PR TITLE
デザインの最終調整

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1144,8 +1144,7 @@ h2 {
 .title-bar {
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
-    margin-bottom: 20px;
+    align-items: center;
 }
 
 .title-bar h1 {
@@ -1155,10 +1154,12 @@ h2 {
 }
 
 .title-text {
-    width: 100%;
+    width: 80%;
+    display:flex;
     border: none;
     border-bottom: 1px solid #ddd;
     padding: 8px;
+    margin: auto;
     font-size: 24px;
     border-radius: 0;
     outline: none;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -145,6 +145,7 @@ a {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: 150%;
   width: 100%;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1587,6 +1587,14 @@ select.ans-form::-ms-expand {
   outline: none;
   box-shadow: 0 0 5px rgba(66, 133, 244, 0.5);
 }
+
+.form-submit:disabled {
+  background-color: #cccccc;
+  /* グレー */
+  color: #666666;
+  /* グレーの文字色 */
+  cursor: not-allowed;
+}
 /* Googleフォーム風のプルダウンリスト */
 .answer-form-select {
   width: 30%;

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -241,6 +241,9 @@ function validateForm() {
     if (!titleText || titleText.value.trim() === "") {
         errors.add("タイトルが入力されていません。");
         titleText.classList.add("error");
+    } else if (titleText.value.length > 50) {
+        errors.add("タイトルの文字数が50文字を超えています。");
+        titleText.classList.add("error");
     } else {
         titleText.classList.remove("error");
     }

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -428,3 +428,14 @@ document.addEventListener("DOMContentLoaded", function () {
         setInterval(updateCountdown, 1000);
     });
 });
+
+document.addEventListener("DOMContentLoaded", function () {
+    // "ques-container"の要素をすべて取得
+    const elements = document.querySelectorAll(".ques-container");
+
+    // 各要素を処理
+    elements.forEach(element => {
+        // data-indexを取得
+        questionCounter = element.getAttribute("data-index");
+    });
+});

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -29,7 +29,7 @@ def list_ques(request):
 @login_required
 def create_ques(request):
     listdict = {
-        'title':'新規作成画面',
+        'title':'新規作成',
     }
     if request.method == 'POST':
         print("POSTデータ:", request.POST)
@@ -265,12 +265,16 @@ def edit_ques(request, survey_id):
 
         path = '/list'
 
+        #公開期間が設定されなかった場合の値
+        default_for_publish = timezone.now() + timedelta(days=365*100)
+
         # 新しいSurveyオブジェクトを作成
         if request.POST.get('action') == 'create':
             survey = Survey(
                 id=next_survey_id,
                 title=survey_title,
                 create_at=timezone.now(),
+                for_publish=default_for_publish,
                 create_user=survey_create_user,
                 published_flag=True,
                 deleted_flag=False
@@ -282,6 +286,7 @@ def edit_ques(request, survey_id):
                 id=next_survey_id,
                 title=survey_title,
                 create_at=timezone.now(),
+                for_publish=default_for_publish,
                 create_user=survey_create_user,
                 published_flag=False,
                 deleted_flag=False
@@ -350,7 +355,7 @@ def edit_ques(request, survey_id):
         survey.save()
         return redirect(path)
     listdict = {
-        'title':'編集画面',
+        'title':'アンケート編集',
         'survey':survey,
         'question':questions,
         'choice':choices,
@@ -438,7 +443,7 @@ def answered(request):
     # ログインしているユーザが回答したアンケートのうち削除済みでないものを表示
     usersanswer = UsersAnswer.objects.filter(user = request.user, answered_survey__deleted_flag=False)
     listdict = {
-        'title': '回答済み一覧',
+        'title': '回答済みアンケート一覧',
         'answered': usersanswer,
     }
     return render(request, 'surveys/answered_list.html', listdict)

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -380,7 +380,6 @@ def answer(request, survey_id):
     return render(request, "answers/answer.html", listdict)
 
 @login_required
-@csrf_exempt  # CSRF保護を一時的に無効にする（開発中のみ）
 def complete(request, survey_id):
     if request.method == 'POST':
         responses = request.POST

--- a/templates/answers/answer.html
+++ b/templates/answers/answer.html
@@ -63,6 +63,17 @@
 
         <input class="form-submit" type="submit" value="送信する">
         <input type="hidden" name="survey_id" value="{{ survey.id }}">
+        <script>
+            document.querySelector('form').addEventListener('submit', function (e) {
+                // ボタンを取得
+                const submitButton = e.target.querySelector('input[type="submit"]');
+                // ボタンを無効化して再送信を防止
+                submitButton.disabled = true;
+                // ボタンのスタイルを変更
+                submitButton.style.backgroundColor = '#cccccc'; // グレーに変更
+                submitButton.style.cursor = 'not-allowed'; // マウスカーソルも変更
+            });
+        </script>
     </form>
 </div>
 {% endblock content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,7 @@
         <p class="username">{{ request.user.email }} でログイン中</p>
         <ul class="menu-items">
             <li><a href="{% url 'templates:list_ques' %}">ホーム</a></li>
-            <li><a href="{% url 'templates:al_list' %}">アンケート一覧</a></li>
+            <li><a href="{% url 'templates:al_list' %}">公開済みアンケート</a></li>
             <li><a href="{% url 'templates:tem_list' %}">下書きアンケート</a></li>
             <li><a href="{% url 'templates:answered' %}">回答済みアンケート</a></li>
             <li>お問い合わせ</li>

--- a/templates/surveys/ag_data.html
+++ b/templates/surveys/ag_data.html
@@ -133,7 +133,7 @@
             charts[index] = new Chart(ctx, config);
 
         } else if (type === 'bar') {
-            const transformedLabels = question.labels.map((label, i) => `${i + 1}:${label}`);
+            const transformedLabels = question.labels.map((label, i) => `${label}`);
 
             const colors = [
                 'rgba(255, 99, 132, 0.8)',

--- a/templates/surveys/ag_data.html
+++ b/templates/surveys/ag_data.html
@@ -101,9 +101,9 @@
             const config = {
                 type: 'pie', // 円グラフ
                 data: {
-                labels: question.labels,
+                    labels: question.labels,
                     datasets: [{
-                    data: question.data,
+                        data: question.data,
                         backgroundColor: [
                             'rgba(255, 99, 132, 0.8)',
                             'rgba(54, 162, 235, 0.8)',
@@ -116,10 +116,10 @@
                     }]
                 },
                 options: {
-                responsive: true,
+                    responsive: true,
                     plugins: {
                         legend: {
-                        position: 'top',
+                            position: 'top',
                         },
                         title: {
                             display: true,
@@ -170,7 +170,7 @@
                     },
                     scales: {
                         x: {
-                    beginAtZero: true
+                            beginAtZero: true
                         }
                     }
                 }

--- a/templates/surveys/ag_data.html
+++ b/templates/surveys/ag_data.html
@@ -96,47 +96,88 @@
             charts[index].destroy();
         }
 
-        const config = {
-            type: type,
-            data: {
+        if (type === 'pie') {
+            // 円グラフの処理（既存コードを使用）
+            const config = {
+                type: 'pie', // 円グラフ
+                data: {
                 labels: question.labels,
-                datasets: [{
+                    datasets: [{
                     data: question.data,
-                    backgroundColor: [
-                        'rgba(255, 99, 132, 0.8)',
-                        'rgba(54, 162, 235, 0.8)',
-                        'rgba(255, 206, 86, 0.8)',
-                        'rgba(75, 192, 192, 0.8)',
-                        'rgba(153, 102, 255, 0.8)'
-                    ],
-                    borderColor: 'rgba(54, 162, 235, 1)',
-                    borderWidth: 1
-                }]
-            },
-            options: {
+                        backgroundColor: [
+                            'rgba(255, 99, 132, 0.8)',
+                            'rgba(54, 162, 235, 0.8)',
+                            'rgba(255, 206, 86, 0.8)',
+                            'rgba(75, 192, 192, 0.8)',
+                            'rgba(153, 102, 255, 0.8)'
+                        ],
+                        borderColor: 'rgba(54, 162, 235, 1)',
+                        borderWidth: 1,
+                    }]
+                },
+                options: {
                 responsive: true,
-                plugins: {
-                    legend: {
+                    plugins: {
+                        legend: {
                         position: 'top',
-                    },
-                    title: {
-                        display: true,
-                        text: getChartTitle(type)
+                        },
+                        title: {
+                            display: true,
+                            text: '円グラフ' // タイトル
+                        }
                     }
                 }
-            }
-        };
+            };
 
-        if (type === 'bar') {
-            config.options.indexAxis = 'y';
-            config.options.scales = {
-                x: {
+            // グラフを作成して保存
+            charts[index] = new Chart(ctx, config);
+
+        } else if (type === 'bar') {
+            const transformedLabels = question.labels.map((label, i) => `${i + 1}:${label}`);
+
+            const colors = [
+                'rgba(255, 99, 132, 0.8)',
+                'rgba(54, 162, 235, 0.8)',
+                'rgba(255, 206, 86, 0.8)',
+                'rgba(75, 192, 192, 0.8)',
+                'rgba(153, 102, 255, 0.8)'
+            ];
+
+            const datasetLabels = transformedLabels.map((label, i) => ({
+                label: label, // 凡例用のラベル
+                data: [question.data[i]], // 対応するデータ
+                backgroundColor: colors[i % colors.length], // 5色を循環して使用
+                borderColor: 'rgba(54, 162, 235, 1)',
+                borderWidth: 1,
+            }));
+
+            const config = {
+                type: 'bar', // 棒グラフ
+                data: {
+                    labels: [''], // 棒グラフのX軸ラベル
+                    datasets: datasetLabels, // データセット
+                },
+                options: {
+                    responsive: true, // レスポンシブ対応
+                    plugins: {
+                        legend: {
+                            position: 'top', // 凡例の位置
+                        },
+                        title: {
+                            display: true, // タイトル表示
+                            text: '棒グラフ' // タイトル
+                        }
+                    },
+                    scales: {
+                        x: {
                     beginAtZero: true
+                        }
+                    }
                 }
             };
+            // グラフを作成して保存
+            charts[index] = new Chart(ctx, config);
         }
-
-        charts[index] = new Chart(ctx, config);
     }
 
     function getChartTitle(type) {

--- a/templates/surveys/answered_list.html
+++ b/templates/surveys/answered_list.html
@@ -26,7 +26,7 @@
                     <td>{{ answer.answered_survey.title }}</td>
                     <td>
                         <a class="detail-btn" href="{% url 'templates:ag_data' answer.answered_survey.id %}">
-                            詳細を見る
+                            回答を確認する
                         </a>
                     </td>
                 </tr>

--- a/templates/surveys/create_ques.html
+++ b/templates/surveys/create_ques.html
@@ -11,7 +11,7 @@
     <div class="container">
         <div class="title-bar">
             <h1>{{ title }}</h1>
-            <input type="text" name="title-text" class="title-text" placeholder="タイトル">
+            <input type="text" id="title-text" name="title-text" class="title-text" placeholder="タイトル" maxlength="50">
             <div class="publish-container">
                 <!-- 公開期間ラベルとプルダウンリスト -->
                 <label for="publish-for_publish" class="publish-label">公開期間</label>
@@ -19,7 +19,6 @@
                     <option value="unlimited">無期限</option>
                     <option value="limited">有期限</option>
                 </select>
-        
                 <!-- 日時入力フォーム -->
                 <div id="publish-datetime-form" class="publish-datetime-form">
                     <label for="publish-date" class="publish-label">終了日時:</label>

--- a/templates/surveys/edit_ques.html
+++ b/templates/surveys/edit_ques.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block base %}
-{{ edittitle }}
+{{ title }}
 {% endblock base %}
 
 {% block content %}
@@ -10,7 +10,7 @@
     {% csrf_token %}
     <div class="container">
         <div class="title-bar">
-            <h1>{{ edittitle }}</h1>
+            <h1>{{ title }}</h1>
             <input type="text" name="title-text" class="title-text" placeholder="タイトルを入力" value="{{ survey.title }}">
             <div class="publish-container">
                 <!-- 公開期間ラベルとプルダウンリスト -->


### PR DESCRIPTION
## 変更点の概要

フォームの送信,タイトル文字の入力制限とサイドメニュー、テンプレートの文字列の変更、グラフ表示のエラーの解決

## 今回変更した点（追加した機能など）
**static/css/style.css**
- 一覧画面の文字が全角と半角で大きさが異なっていたため同じになるように調整
- 回答画面のデザインの編集
- フォーム送信ボタンを1回で使えなくし、ボタンを灰色に変更する処理の追加

**static/js/common.js**
- タイトルが50字以上の時にエラーを出力するように編集
- 下書きリストから編集画面に遷移した際に質問を作成しないとアンケートを作成できないバグの修正

**surveys/views.py**
- create_ques,edit_ques,answeredのタイトルの変更
- 公開期間が設定されなかった下書き保存の際のバグの修正
- csrf保護の無効化の削除

**templates/answers/answer.html**
- フォーム送信ボタンを1回で使えなくする処理

**templates/base.html**
- サイドメニューの"アンケート一覧"を"公開済みアンケート"に変更

**templates/surveys/ag_data.html**
- グラフ表示がうまくいかないバグの修正

**templates/surveys/answered_list.html**
- 詳細を見る→回答を確認する

**templates/surveys/create_ques.html**
- タイトルを50字以上入力できなくする処理

**templates/surveys/edit_ques.html**
- タイトルが正しく表示されるようにdjangoタグを編集

## 今回やらなかったこと（次回プルリクで行うものなど）

特になし

## この変更でできるようになること

デザインの調整

## できなくなること

特になし

## 動作確認

エラーの調整等を行った

## その他・疑問点など

特になし